### PR TITLE
ci: introduce mergify to automate merge flow

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,115 @@
+queue_rules:
+  - name: shared_queue
+    conditions:
+      - check-success=unit-test
+      - check-success=e2e-test-spark
+      - check-success=e2e-test-postgres
+      - check-success=e2e-test-clickhouse
+      - check-success=test-coverage-all
+
+pull_request_rules:
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  # Push PR into queue when it passes all checks
+  - name: put approved pr to queue
+    conditions:
+      - or:
+        - and:
+          - "#approved-reviews-by>=1"
+          - -draft
+          - check-success=unit-test
+          - check-success=e2e-test-spark
+          - check-success=e2e-test-postgres
+          - check-success=e2e-test-clickhouse
+          - check-success=test-coverage-all
+        - and:
+          - label=can-merge
+          - -draft
+          - check-success=unit-test
+          - check-success=e2e-test-spark
+          - check-success=e2e-test-postgres
+          - check-success=e2e-test-clickhouse
+          - check-success=test-coverage-all
+    actions:
+      queue:
+        name: shared_queue
+        method: squash
+
+  # Check if PR title contain valid types
+  - name: Comment PR if title not semantic
+    conditions:
+      - author!=Mergify
+      - -draft
+      - '-title~=^(feat|fix|refactor|ci|build|docs|website|chore)(\(.*\))?:'
+    actions:
+      comment:
+        message: |
+          This pull request's title is not fulfill the requirements. @{{author}} please update it 🙏.
+
+          Valid format:
+
+          ```
+          fix(query): fix group by string bug
+            ^         ^---------------------^
+            |         |
+            |         +-> Summary in present tense.
+            |
+            +-------> Type: feat, fix, refactor, ci, build, docs, website, chore
+          ```
+
+          Valid types:
+
+          - `feat`: this PR introduces a new feature to the codebase
+          - `fix`: this PR patches a bug in codebase
+          - `refactor`: this PR changes the code base without new features or bugfix
+          - `ci|build`: this PR changes build/testing/ci steps
+          - `docs|website`: this PR changes the documents or websites
+          - `chore`: this PR only has small changes that no need to record
+
+  # Assign pr label based of tags
+  - name: label on New Feature
+    conditions:
+      - 'title~=^(feat)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-feature
+  - name: label on Bug Fix
+    conditions:
+      - 'title~=^(fix)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-bugfix
+  - name: label on Refactor
+    conditions:
+      - 'title~=^(refactor)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-refactor
+  - name: label on Build/Testing/CI
+    conditions:
+      - 'title~=^(ci|build)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-build
+  - name: label on Documentation
+    conditions:
+      - 'title~=^(docs|website)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-doc
+  - name: label on Not for changelog
+    conditions:
+      - 'title~=^(chore)(\(.*\))?:'
+    actions:
+      label:
+        add:
+          - pr-chore

--- a/easy_sql/sql_tester_test.py
+++ b/easy_sql/sql_tester_test.py
@@ -85,4 +85,6 @@ class TestCaseParserTest(unittest.TestCase):
         self.assertEqual(input.columns, ["id", "val", "val_date", "data_date"])
         self.assertEqual(input.column_types, ["int", "string", "date", "date"])
         self.assertEqual(input.values, [[1, "1.0", datetime(2021, 1, 1, 0, 0), datetime(2021, 1, 1, 0, 0)]])
-        self.assertEqual(case.outputs[0].values, [[1, "1.0", datetime(2021, 1, 1, 0, 0)], [1, "2.0", None], [1, "3.0", None]])
+        self.assertEqual(
+            case.outputs[0].values, [[1, "1.0", datetime(2021, 1, 1, 0, 0)], [1, "2.0", None], [1, "3.0", None]]
+        )


### PR DESCRIPTION
close https://github.com/easysql/easy_sql/issues/19

I draft a basic mergify configuration which includes:
- check action success before merging PR
- auto `merge squash` when `approved-reviews-by>=1` or `PR with can-merge label`
- check PR title is semantic or not
- auto label PR by semantic title, such as `pr-feature`, `pr-doc`, `pr-bugfix`, or something else

In addition, we should install [mergify](https://docs.mergify.com/getting-started/#installation) to enable this configuration.

Sure, this is a basic version, we could enhance it if need other requirements, could refer to [mergify example-rules](https://docs.mergify.com/examples/#example-rules)

Signed-off-by: Fedomn <fedomn.ma@gmail.com>