### PR TITLE
fix(rdb): use dialect to compile instead stringify when inspect rdb type info

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-ut
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-ut-1 # increase the number if you updated below install cmd
     - run: poetry install --no-interaction -E "spark linter pg"
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     - run: poetry run make unit-test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-ut
-    - run: poetry install --no-interaction -E "spark linter"
+    - run: poetry install --no-interaction -E "spark linter pg"
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     - run: poetry run make unit-test
     - run: poetry run make test-coverage

--- a/easy_sql/sql_processor/backend/rdb.py
+++ b/easy_sql/sql_processor/backend/rdb.py
@@ -470,8 +470,8 @@ class RdbBackend(Backend):
                 col["type"] = col_type.compile(self.inspector.dialect)
         return cols
 
-    def get_column_names(self, table_name, schema=None, raw=False, **kw) -> List[str]:
-        cols = self.get_columns(table_name, schema, raw, **kw)
+    def get_column_names(self, table_name, schema=None, **kw) -> List[str]:
+        cols = self.get_columns(table_name, schema, raw=True, **kw)
         names = [col["name"] for col in cols if "name" in col]
         return names
 

--- a/easy_sql/sql_processor/backend/rdb.py
+++ b/easy_sql/sql_processor/backend/rdb.py
@@ -471,7 +471,7 @@ class RdbBackend(Backend):
         return cols
 
     def get_column_names(self, table_name, schema=None, raw=False, **kw) -> List[str]:
-        cols = self.get_columns(table_name, schema=None, raw=True, **kw)
+        cols = self.get_columns(table_name, schema, raw, **kw)
         names = [col["name"] for col in cols if "name" in col]
         return names
 
@@ -618,7 +618,7 @@ class RdbBackend(Backend):
         self._ensure_contain_target_cols(source_col_names, target_col_names)
 
         if save_mode == SaveMode.overwrite:
-            self._overwrite(source_table, target_table, original_source_table, source_col_names)
+            self._overwrite(source_table, target_table, original_source_table, target_col_names)
         elif save_mode == SaveMode.append:
             self._append(source_table, target_table, original_source_table, target_col_names)
         else:

--- a/easy_sql/sql_processor/backend/rdb.py
+++ b/easy_sql/sql_processor/backend/rdb.py
@@ -274,9 +274,9 @@ class RdbTable(Table):
                     f" {target_table.table_name}, all fields are in source table: {field_names}"
                 )
 
-        cols = self.backend.inspector.get_columns(temp_table_name, self.backend.temp_schema)
+        cols = self.backend.get_columns(temp_table_name, self.backend.temp_schema)
         if self.backend.table_exists(target_table):
-            cols = self.backend.inspector.get_columns(target_table.pure_table_name, target_table.dbname)
+            cols = self.backend.get_columns(target_table.pure_table_name, target_table.dbname)
         else:
             db = target_table.table_name[: target_table.table_name.index(".")]
             self._exec_sql(self.db_config.create_db_sql(db))

--- a/easy_sql/sql_processor/backend/rdb_test.py
+++ b/easy_sql/sql_processor/backend/rdb_test.py
@@ -1,22 +1,5 @@
 import unittest
 
-from easy_sql.sql_processor.backend import Partition
-from easy_sql.sql_processor.backend.rdb import ChSqlDialect, SqlExpr
-
 
 class RdbTest(unittest.TestCase):
-    def test_ch_config(self):
-        ch_config = ChSqlDialect(SqlExpr(), "dataplat.__table_partitions__")
-        sql = ch_config.delete_partition_sql("test.test", [Partition("dt", "20210101")])
-        self.assertEqual(
-            sql,
-            [
-                "alter table test.test drop partition tuple('20210101')",
-                "alter table dataplat.__table_partitions__ delete "
-                "where db_name = 'test' and table_name = 'test' and partition_value = '20210101'",
-            ],
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+    ...

--- a/easy_sql/sql_processor/backend/rdb_test.py
+++ b/easy_sql/sql_processor/backend/rdb_test.py
@@ -1,5 +1,43 @@
 import unittest
+from unittest.mock import patch
+
+from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
+from sqlalchemy.engine import Inspector, create_mock_engine
+
+from easy_sql.sql_processor.backend.rdb import RdbBackend
 
 
 class RdbTest(unittest.TestCase):
-    ...
+    def test_get_column_names_should_only_get_from_name(self):
+        cols = [{"name": "a"}, {"name": "b"}, {"type": "c"}]
+        with patch.object(RdbBackend, "get_columns", return_value=cols):
+            rdb = RdbBackend("")
+            names = rdb.get_column_names("test")
+            self.assertSequenceEqual(names, ["a", "b"])
+
+    def test_get_columns_should_compile_type_by_dialect_when_now_raw(self):
+        mock_engine = create_mock_engine("postgresql://", None)
+        mock_engine.close = lambda: None
+        col = {"name": "id", "type": DOUBLE_PRECISION(10)}
+        raw_cols = [col]
+        with patch.object(Inspector, "get_columns", return_value=[col.copy() for col in raw_cols]):
+            rdb = RdbBackend("")
+            rdb.engine = mock_engine
+
+            cols = rdb.get_columns("test")
+
+            self.assertNotEqual(str(col["type"]), "DOUBLE PRECISION")
+            self.assertEqual(cols, [{"name": "id", "type": "DOUBLE PRECISION"}])
+
+    def test_get_columns_should_compile_type_by_dialect_when_in_raw(self):
+        mock_engine = create_mock_engine("postgresql://", None)
+        mock_engine.close = lambda: None
+        col = {"name": "id", "type": DOUBLE_PRECISION(10)}
+        raw_cols = [col]
+        with patch.object(Inspector, "get_columns", return_value=[col.copy() for col in raw_cols]):
+            rdb = RdbBackend("")
+            rdb.engine = mock_engine
+
+            cols = rdb.get_columns("test", raw=True)
+
+            self.assertEqual(cols, raw_cols)

--- a/easy_sql/sql_processor/backend/sql_dialect/clickhouse_test.py
+++ b/easy_sql/sql_processor/backend/sql_dialect/clickhouse_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from easy_sql.sql_processor.backend import Partition
+from easy_sql.sql_processor.backend.sql_dialect import SqlExpr
+from easy_sql.sql_processor.backend.sql_dialect.clickhouse import ChSqlDialect
+
+
+class RdbTest(unittest.TestCase):
+    def test_ch_config(self):
+        ch_config = ChSqlDialect(SqlExpr(), "dataplat.__table_partitions__")
+        sql = ch_config.delete_partition_sql("test.test", [Partition("dt", "20210101")])
+        self.assertEqual(
+            sql,
+            [
+                "alter table test.test drop partition tuple('20210101')",
+                "alter table dataplat.__table_partitions__ delete "
+                "where db_name = 'test' and table_name = 'test' and partition_value = '20210101'",
+            ],
+        )


### PR DESCRIPTION
see: https://github.com/sqlalchemy/sqlalchemy/commit/0721a6bede7222386b2a2508aac5590909fbb148#diff-11f1fd0f775da0862d27dad23b5f9a801df9ea8ade1b55fbd0e84bd888fe4f4d

The new version of `sqlalchemy` will use `StrCompileDialect` by default when assigning nothing, but the default one might not be compatible with the specific dialect. e.g. `double precision` here.

So we will pass the dialect from the inspector into the TypeEngine's `compile` method to generate the proper results.