### PR TITLE
ci: support auto release and publish package

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -44,7 +44,7 @@ pull_request_rules:
     conditions:
       - author!=Mergify
       - -draft
-      - '-title~=^(feat|fix|refactor|ci|build|docs|website|chore)(\(.*\))?:'
+      - '-title~=^(feat|fix|refactor|ci|build|docs|website|chore)(\(.*\))?!?:'
     actions:
       comment:
         message: |
@@ -69,6 +69,8 @@ pull_request_rules:
           - `ci|build`: this PR changes build/testing/ci steps
           - `docs|website`: this PR changes the documents or websites
           - `chore`: this PR only has small changes that no need to record
+          - `type(scope)!`: this type of PR introduces breaking changes to the codebase
+
 
   # Assign pr label based of tags
   - name: label on New Feature
@@ -113,3 +115,10 @@ pull_request_rules:
       label:
         add:
           - pr-chore
+  - name: label on breaking changes
+    conditions:
+      - 'title~=^.*?(\(.*\))?!:'
+    actions:
+      label:
+        add:
+          - pr-breaking

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,34 +7,31 @@ template: |
 
 categories:
   - title: 'Breaking'
-    label: 'type: breaking'
+    label: 'pr-breaking'
   - title: 'New'
-    label: 'type: feature'
+    label: 'pr-feature'
   - title: 'Bug Fixes'
-    label: 'type: bug'
+    label: 'pr-bugfix'
   - title: 'Maintenance'
-    label: 'type: maintenance'
+    label: 'pr-refactor'
   - title: 'Documentation'
-    label: 'type: docs'
+    label: 'pr-doc'
   - title: 'Other changes'
-  - title: 'Dependency Updates'
-    label: 'type: dependencies'
-    collapse-after: 5
 
 version-resolver:
   major:
     labels:
-      - 'type: breaking'
+      - 'pr-breaking'
   minor:
     labels:
-      - 'type: feature'
+      - 'pr-feature'
   patch:
     labels:
-      - 'type: bug'
-      - 'type: maintenance'
-      - 'type: docs'
-      - 'type: dependencies'
-      - 'type: security'
+      - 'pr-bugfix'
+      - 'pr-refactor'
+      - 'pr-build'
+      - 'pr-doc'
+      - 'pr-chore'
 
 exclude-labels:
   - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,40 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: feature'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Maintenance'
+    label: 'type: maintenance'
+  - title: 'Documentation'
+    label: 'type: docs'
+  - title: 'Other changes'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+    collapse-after: 5
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,14 @@
+name: draft-release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,4 +1,4 @@
-name: draft-release
+name: Draft Release
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  update_release_draft:
+  update-release-draft:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@master

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -3,7 +3,7 @@ name: draft-release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,10 @@ jobs:
         tag=${GITHUB_REF_NAME}
         version=${tag#v}
         old_version=$(poetry version -s)
-        echo "tags: $tag , version: $version"
+        echo "tags: $tag , version: $version , old_version: $old_version"
         echo "::set-output name=tag::${tag}"
         echo "::set-output name=version::${version}"
-        echo "::set-output name=version_changed::$( [ $version = $old_version ] && echo 'true' )"
+        echo "::set-output name=version_changed::$( [ $version != $old_version ] && echo 'true' )"
     - name: bump version
       if: ${{ steps.version.outputs.version_changed == 'true' }}
       run: poetry version ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,13 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
     - name: version
-        id: version
-        run: |
-          tag=${GITHUB_REF_NAME}
-          version=${tag#v}
-          echo "tags: ${tag} , version: ${version}"
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=version::${version}"
+      id: version
+      run: |
+        tag=${GITHUB_REF_NAME}
+        version=${tag#v}
+        echo "tags: ${tag} , version: ${version}"
+        echo "::set-output name=tag::${tag}"
+        echo "::set-output name=version::${version}"
     - name: bump version
       run: poetry version ${{ steps.version.outputs.version }}
     - name: update release tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,22 +23,29 @@ jobs:
         key: poetry-0  # increment to reset cache
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
-    - name: version
+    - name: version check
       id: version
       run: |
         tag=${GITHUB_REF_NAME}
         version=${tag#v}
-        echo "tags: ${tag} , version: ${version}"
+        old_version=$(poetry version -s)
+        echo "tags: $tag , version: $version"
         echo "::set-output name=tag::${tag}"
         echo "::set-output name=version::${version}"
+        echo "::set-output name=version_changed::$(( $old_version == $version ))"
     - name: bump version
+      if: ${{ steps.version.outputs.version_changed == 1 }}
       run: poetry version ${{ steps.version.outputs.version }}
-    - name: update release tag
+    - name: commit and update release tag
+      if: ${{ steps.version.outputs.version_changed == 1 }}
       run: |
-            git config user.name 'auto-release'
-            git config user.email 'easy_sql@thoughtworks.com'
-            git commit -am "release: bump to version ${{ steps.version.outputs.version }} [skip ci]"
-            git tag ${{ steps.version.outputs.tag }} -f
-            git push --atomic origin main ${{ steps.version.outputs.tag }} -f
+        git config user.name 'auto-release'
+        git config user.email 'easy_sql@thoughtworks.com'
+        git commit -am "release: bump to version ${{ steps.version.outputs.version }} [skip ci]"
+        git tag ${{ steps.version.outputs.tag }} -f
+        git push --atomic origin main ${{ steps.version.outputs.tag }} -f
     - name: upload pypi
-      run: make upload-pip
+      if: ${{ steps.version.outputs.version_changed == 1 }}
+      run: |
+        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+        make upload-pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        ref: main
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8
@@ -18,7 +19,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /home/runner/.local/  # the path depends on the OS
-        key: poetry-1  # increment to reset cache
+        key: poetry-0  # increment to reset cache
     - name: Install Poetry
       uses: snok/install-poetry@v1.3.1
     - name: version
@@ -35,8 +36,8 @@ jobs:
       run: |
             git config user.name 'auto-release'
             git config user.email 'easy_sql@thoughtworks.com'
-            git commit -am "release: bump to version ${{ steps.version.outputs.version }}"
-            git tag v${{ steps.version.outputs.version }} -f
-            git push origin main --follow-tags
+            git commit -am "release: bump to version ${{ steps.version.outputs.version }} [skip ci]"
+            git tag ${{ steps.version.outputs.tag }} -f
+            git push --atomic origin main ${{ steps.version.outputs.tag }} -f
     - name: upload pypi
       run: make upload-pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,12 +32,12 @@ jobs:
         echo "tags: $tag , version: $version"
         echo "::set-output name=tag::${tag}"
         echo "::set-output name=version::${version}"
-        echo "::set-output name=version_changed::$(( $old_version == $version ))"
+        echo "::set-output name=version_changed::$( [ $version = $old_version ] && echo 'true' )"
     - name: bump version
-      if: ${{ steps.version.outputs.version_changed == 1 }}
+      if: ${{ steps.version.outputs.version_changed == 'true' }}
       run: poetry version ${{ steps.version.outputs.version }}
     - name: commit and update release tag
-      if: ${{ steps.version.outputs.version_changed == 1 }}
+      if: ${{ steps.version.outputs.version_changed == 'true' }}
       run: |
         git config user.name 'auto-release'
         git config user.email 'easy_sql@thoughtworks.com'
@@ -45,7 +45,7 @@ jobs:
         git tag ${{ steps.version.outputs.tag }} -f
         git push --atomic origin main ${{ steps.version.outputs.tag }} -f
     - name: upload pypi
-      if: ${{ steps.version.outputs.version_changed == 1 }}
+      if: ${{ steps.version.outputs.version_changed == 'true' }}
       run: |
         poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
         make upload-pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: main
-        ssh-key: ${{ secrets.DEPLOY_KEY }}
+        # ssh-key: ${{ secrets.DEPLOY_KEY }}
+        token: ${{ secrets.PAT }}
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Load cached Poetry installation
+      uses: actions/cache@v2
+      with:
+        path: /home/runner/.local/  # the path depends on the OS
+        key: poetry-1  # increment to reset cache
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.3.1
+    - name: version
+        id: version
+        run: |
+          tag=${GITHUB_REF_NAME}
+          version=${tag#v}
+          echo "tags: ${tag} , version: ${version}"
+          echo "::set-output name=tag::${tag}"
+          echo "::set-output name=version::${version}"
+    - name: bump version
+      run: poetry version ${{ steps.version.outputs.version }}
+    - name: update release tag
+      run: |
+            git config user.name 'auto-release'
+            git config user.email 'easy_sql@thoughtworks.com'
+            git commit -am "release: bump to version ${{ steps.version.outputs.version }}"
+            git tag v${{ steps.version.outputs.version }} -f
+            git push origin main --follow-tags
+    - name: upload pypi
+      run: make upload-pip

--- a/pyproject.old.toml
+++ b/pyproject.old.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools>=42"]
-build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "easy_sql-easy_sql"
+name = "easy_sql-easy_sql-j"
 version = "0.3.0"
 description = "A library developed to ease the data ETL development process."
 authors = ["Easy SQL from Thoughtworks <easy_sql@thoughtworks.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "easy_sql-easy_sql-j"
+name = "easy_sql-easy_sql"
 version = "0.3.0"
 description = "A library developed to ease the data ETL development process."
 authors = ["Easy SQL from Thoughtworks <easy_sql@thoughtworks.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "easy_sql-easy_sql"
-version = "0.4.0"
+version = "0.3.0"
 description = "A library developed to ease the data ETL development process."
 authors = ["Easy SQL from Thoughtworks <easy_sql@thoughtworks.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Should fix #24.

After this implementation, if there is PR that merged, it will trigger the draft-release action which will generate a draft release for us including auto-generated change logs from the last release.

If we are ready to release, we can go to the release panel and publish the drafted release (we can modify it at the moment if it does not meet our needs, like the auto-generated tag version or release notes). After that, it will trigger the release action, which will bump the version and upload the package in PyPI automatically.

All we need to do is pick an appropriate time to publish the drafted release.