### PR TITLE
fix(docs): update easy-sql pip package name from "easy_sql-easy_sql" to "easy-sql-easy-sql"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ spark-warehouse/
 build/*
 .ipynb_checkpoints/
 easy_sql-easy_sql*
+easy-sql-easy-sql*
 easy_sql_easy_sql.egg-info
 dist/
 dist.old/

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ upload-test-pip:
 
 install-test-pip:
 	pip3 uninstall easy_sql-easy_sql
-	python3 -m pip install --index-url https://test.pypi.org/simple/ easy_sql-easy_sql[cli]
+	python3 -m pip install --index-url https://test.pypi.org/simple/ 'easy-sql-easy-sql[cli]'
 
 upload-pip:
 	rm -rf ./dist

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ More will be added in the near future.
 
 ## Install Easy SQL
 
-Install Easy SQL using pip: `python3 -m pip install easy_sql-easy_sql[extra,extra]`
+Install Easy SQL using pip: `python3 -m pip install 'easy-sql-easy-sql[extra,extra]'`
 
 Currently we are providing below extras, choose according to your need:
 - cli
@@ -40,7 +40,7 @@ You can install it with command `python3 -m pip install dist/easy_sql*.whl[extra
 
 ## First ETL with Easy SQL
 
-Install easy_sql with spark as the backend: `python3 -m pip install easy_sql-easy_sql[spark,cli]`.
+Install easy_sql with spark as the backend: `python3 -m pip install 'easy-sql-easy-sql[spark,cli]'`.
 
 ### For spark backend
 
@@ -97,7 +97,7 @@ docker run -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=123456 postgres
 
 Create a file named `sample_etl.postgres.sql` with content as the test file [here](https://github.com/easysql/easy_sql/blob/main/test/sample_etl.postgres.sql).
 
-Make sure that you have install the corresponding backend with `python3 -m pip install easy-sql-easy-sql[cli,pg]`
+Make sure that you have install the corresponding backend with `python3 -m pip install 'easy-sql-easy-sql[cli,pg]'`
 
 Run it with command:
 
@@ -117,7 +117,7 @@ docker run -d --name clickhouse -p 9000:9000 yandex/clickhouse-server:20.12.5.18
 
 Create a file named `sample_etl.clickhouse.sql` with content as the test file [here](https://github.com/easysql/easy_sql/blob/main/test/sample_etl.clickhouse.sql).
 
-Make sure that you have install the corresponding backend with `python3 -m pip install easy-sql-easy-sql[cli,clickhouse]`
+Make sure that you have install the corresponding backend with `python3 -m pip install 'easy-sql-easy-sql[cli,clickhouse]'`
 
 Run it with command:
 

--- a/docs/easy_sql/build_install.md
+++ b/docs/easy_sql/build_install.md
@@ -5,7 +5,7 @@ It's easy to build or install Easy SQL.
 
 ## Install Easy SQL
 
-Install Easy SQL using pip: `python3 -m pip install easy_sql-easy_sql[extra,extra]`
+Install Easy SQL using pip: `python3 -m pip install 'easy-sql-easy-sql[extra,extra]'`
 
 Currently we are providing below extras, choose according to your need:
 - cli

--- a/docs/easy_sql/quick_start.md
+++ b/docs/easy_sql/quick_start.md
@@ -2,7 +2,7 @@
 
 ## First ETL with Easy SQL
 
-Install easy_sql with spark as the backend: `python3 -m pip install easy_sql-easy_sql[spark,cli]`.
+Install easy_sql with spark as the backend: `python3 -m pip install 'easy-sql-easy-sql[spark,cli]'`.
 
 ### For spark backend
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,7 +8,7 @@ ADD sample_etl.spark.sql /tmp
 ADD sample_etl.postgres.sql /tmp
 ADD sample_etl.clickhouse.sql /tmp
 
-RUN python3 -m pip install easy_sql-easy_sql[spark,pg,clickhouse,cli]
+RUN python3 -m pip install 'easy-sql-easy-sql[spark,pg,clickhouse,cli]'
 
 ARG PG_URL=
 ARG CLICKHOUSE_URL=


### PR DESCRIPTION
`python3 -m pip install easy_sql-easy_sql[extra,extra]` could not work correctly because:
1. the package name `easy_sql-easy_sql` has been updated to `easy-sql-easy-sql` in [pypi.org](https://pypi.org/project/easy-sql-easy-sql/)
2. missing single quote between the package name so that the shell parse the package name incorrectly 

this PR is to update the package name from `easy_sql-easy_sql` to `easy-sql-easy-sql` and add single quote besides the package name.